### PR TITLE
Exclude .map files for Sprockets

### DIFF
--- a/lib/polymer-rails/processors/component.rb
+++ b/lib/polymer-rails/processors/component.rb
@@ -53,6 +53,7 @@ module Polymer
           search_file = file.sub(/^(\.\.\/)+/, '/').sub(/^\/*/, '')
           ::Rails.application.assets.paths.each do |path|
             file_list = Dir.glob( "#{File.absolute_path search_file, path }*")
+            file_list.delete_if { |path| path =~ /\.map$/ }
             return file_list.first unless file_list.blank?
           end
           components = Dir.glob("#{File.absolute_path file, File.dirname(@context.pathname)}*")


### PR DESCRIPTION
Hi!

I've got some problems in production with polymer-rails. The component paper-dropdown uses animations and it is has a .js.map file. 

Sometimes while compile assets the map file goes first in **file_list** array [here](https://github.com/alchapone/polymer-rails/blob/master/lib/polymer-rails/processors/component.rb#L55). As a result the source of this file is placed to the script tag in **application.html** instead of desired content.

I just made a quick fix for that. Could you review it and make some changes in the gem? 

Thank you in advance!
