### PR TITLE
Unescape src attribute one-way and two-way binding

### DIFF
--- a/lib/polymer-rails/xml_adapters/nokogiri.rb
+++ b/lib/polymer-rails/xml_adapters/nokogiri.rb
@@ -28,7 +28,11 @@ module Polymer
 
         def stringify doc
           xml_nodes(doc).reduce(to_html(doc)) do |output, node|
-            output.gsub(node.to_html, node.to_xml(XML_OPTIONS)).encode(ENCODING)
+            pattern = node.to_html
+            replacement = node.to_xml(XML_OPTIONS)
+            replacement.gsub!( /src="%5B%5B(.+?)%5D%5D"/i, 'src="[[\1]]"' )
+            replacement.gsub!( /src="%7B%7B(.+?)%7D%7D"/i, 'src="{{\1}}"' )
+            output.gsub(pattern, replacement).encode(ENCODING)
           end
         end
 

--- a/spec/component_spec.rb
+++ b/spec/component_spec.rb
@@ -18,6 +18,10 @@ describe Polymer::Rails::Component do
       <link rel="import" href="2.html">'
   }
 
+  let(:img_tag){'<img src="[[link1]]" attr="[[attr1]]">
+      <img src="{{link2}}" attr="{{attr2}}">'
+  }
+
   context '#replace_node' do
     subject do
       doc = described_class.new(data)
@@ -77,10 +81,20 @@ describe Polymer::Rails::Component do
   end
 
   context '#stringify' do
-    subject{ described_class.new(data).stringify }
+    context 'regular html' do
+      subject{ described_class.new(data).stringify }
 
-    it 'should return html string' do
-      expect(subject.squish).to eq(data.squish)
+      it 'should return html string' do
+        expect(subject.squish).to eq(data.squish)
+      end
+    end
+
+    context 'img tag with one-way and two-way binding' do
+      subject{ described_class.new(img_tag).stringify }
+
+      it 'should return html string' do
+        expect(subject.squish).to eq(img_tag.squish)
+      end
     end
   end
 


### PR DESCRIPTION
Hi,

I was having some issue with polymer-rails and polymer-elements-rails (specifically paper-card) described in https://github.com/PolymerElements/paper-card/issues/17.  

paper-card uses `src="[[image]]"` binding and nokogiri is escaping the brackets into `src="%5B%5Bimage%5D%5D"`.  Similar issue exists with paper-icon-button and iron-component-page. This PR un-escape `src="%5B%5Bxxx%5D%5D"` and `src="%7B%7Bxxx%7D%7D"` back into respective `src="[[xxx]]"` and `src="{{xxx}}"`.

Regards,
thetno