### PR TITLE
Updated component generator to work with nested paths

### DIFF
--- a/lib/generators/polymer/component/component_generator.rb
+++ b/lib/generators/polymer/component/component_generator.rb
@@ -20,7 +20,7 @@ module Polymer
       end
       
       def component_base_name
-        component_name.split['/'][-1]
+        component_name.split('/')[-1]
       end
     end
   end

--- a/lib/generators/polymer/component/component_generator.rb
+++ b/lib/generators/polymer/component/component_generator.rb
@@ -8,15 +8,19 @@ module Polymer
       end
 
       def copy_component_template
-        template "component.html.erb", "app/assets/components/#{component_name}/#{component_name}.html"
-        template "component.js.erb", "app/assets/components/#{component_name}/#{component_name}.js"
-        template "component.css.erb", "app/assets/components/#{component_name}/#{component_name}.css"
+        template "component.html.erb", "app/assets/components/#{component_name}/#{component_base_name}.html"
+        template "component.js.erb", "app/assets/components/#{component_name}/#{component_base_name}.js"
+        template "component.css.erb", "app/assets/components/#{component_name}/#{component_base_name}.css"
       end
 
       private
 
       def component_name
         name.gsub('_', '-').downcase
+      end
+      
+      def component_base_name
+        component_name.split['/'][-1]
       end
     end
   end

--- a/lib/generators/polymer/component/templates/component.html.erb
+++ b/lib/generators/polymer/component/templates/component.html.erb
@@ -1,9 +1,9 @@
-<dom-module id="<%= component_name %>">
-  <link rel="stylesheet" href="<%= component_name %>.css" />
+<dom-module id="<%= component_base_name %>">
+  <link rel="stylesheet" href="<%= component_base_name %>.css" />
   <template>
 
     <h2><%= file_name.capitalize.gsub('_', ' ') %></h2>
   </template>
 
-  <script src="<%= component_name %>.js"></script>
+  <script src="<%= component_base_name %>.js"></script>
 </dom-module>

--- a/lib/generators/polymer/component/templates/component.js.erb
+++ b/lib/generators/polymer/component/templates/component.js.erb
@@ -1,3 +1,3 @@
 Polymer({
-  is: "<%= component_name %>"
+  is: "<%= component_base_name %>"
 });


### PR DESCRIPTION
Updated the component generator to be able to generate components in directories, the same way the model/controller generator works in rails.

`rails g polymer:component my-sub-directory/component-name`

with the changes, the generator will generate the component files in the correct directory
```
app/assets/components/my-sub-directory/component-name
app/assets/components/my-sub-directory/component-name/component-name.html
app/assets/components/my-sub-directory/component-name/component-name.js
app/assets/components/my-sub-directory/component-name/component-name.css
```

The current generator would create an extra directory inside the component directory, and have wrong references in the js file. The current generator will create.
```
app/assets/components/my-sub-directory/component-name/my-sub-directory
app/assets/components/my-sub-directory/component-name/my-sub-directory/component-name.html
app/assets/components/my-sub-directory/component-name/my-sub-directory/component-name.js
app/assets/components/my-sub-directory/component-name/my-sub-directory/component-name.css
```